### PR TITLE
fix spelling of "Stack Overflow"

### DIFF
--- a/support.html
+++ b/support.html
@@ -62,7 +62,7 @@
         <p>
           The <a href="https://groups.google.com/d/forum/openwisp/join" target="_blank">mailing list</a>
           is suited for broad discussions, asking for clarifications, announcements
-          and any other question that is not suited for stackoverflow.</p>
+          and any other question that is not suited for Stack Overflow.</p>
         <p class="center buttons">
           <a href="https://groups.google.com/d/forum/openwisp/join"
              class="ui big inverted button red" target="_blank">
@@ -91,7 +91,7 @@
         </ul>
         <p>
           If nobody can reply to your questions while you are there, send your
-          questions on other asynchronous support channles (forum, mailing list, stackoverflow).
+          questions on other asynchronous support channles (forum, mailing list, Stack Overflow).
         </p>
         <p class="center buttons">
           <a href="https://gitter.im/openwisp/general"
@@ -113,20 +113,20 @@
           </a>
         </p>
 
-        <h2>Stackoverflow</h2>
+        <h2>Stack Overflow</h2>
         <p>
           As of March 2017, we created a dedicated
           <a href="http://stackoverflow.com/questions/tagged/openwisp" target="_blank">
             OpenWISP tag
           </a>
-          on StackOverflow.</a>
+          on Stack Overflow.</a>
         </p>
         <p>
           <strong>Use this method if your question is very technical
           and may have a single, definitive, best answer</strong>.
         </p>
         <p>
-          Asking questions on stackoverflow using the <em>openwisp</em> tag will
+          Asking questions on Stack Overflow using the <em>openwisp</em> tag will
           help the project gain popularity,
           therefore we ask you to use this method whenever possible.
         </p>
@@ -140,7 +140,7 @@
           <a href="http://stackoverflow.com/questions/ask?tags=openwisp"
              class="ui big inverted button red" target="_blank">
             <i class="stack overflow icon"></i>
-            Ask a question on StackOverflow
+            Ask a question on Stack Overflow
           </a>
         </p>
       </article>


### PR DESCRIPTION
Sorry, but as a Stack Exchange user this was seriously bugging me on your /support page. The proper name of the site is "Stack Overflow" - with a space, and both words capitalized.