### PR TITLE
[gci] Remove deprecated Travis keys

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,8 @@
 language: python
 node_js: "stable"
-sudo: false
 cache: pip
 python:  3.6
-
+os: linux
 before_install:
   - npm install -g npm@latest
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: python
 node_js: "stable"
 cache: pip
 python:  3.6
-os: linux
 before_install:
   - npm install -g npm@latest
 


### PR DESCRIPTION
This pull request removes reference to deprecated Travis CI `sudo: true`, and adds `os: linux` as per https://config.travis-ci.com/explore.

Google Code-in Link: https://codein.withgoogle.com/tasks/6251383070654464