### PR TITLE
[ci] Remove deprecated travis key

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,5 @@
 language: python
 node_js: "stable"
-sudo: false
 cache: pip
 python:  3.6
 


### PR DESCRIPTION
This pull request removes reference to deprecated Travis CI `sudo: true`.

Google Code-in Link: https://codein.withgoogle.com/tasks/6251383070654464
This is Code-in user aaPle.