### PR TITLE
[Fix] Fixed "Infinity seconds ago" bug in activity feed #46

### DIFF
--- a/js/feed.js
+++ b/js/feed.js
@@ -11,7 +11,7 @@ function createActivityFeed(options) {
   function timeSince(date) {
     var seconds = Math.floor((Date.now() - date.getTime()) / 1000);
     var interval = intervals.find(i => i.seconds < seconds);
-    var count = Math.floor(seconds / interval.seconds);
+    var count =  (interval.seconds === 0 ? seconds : Math.floor(seconds / interval.seconds));
     return count + " " + interval.label + (count !== 1 ? "s" : "") + " ago";
   }
 


### PR DESCRIPTION
Fixed the issue which caused the activity feed to show "Infinity seconds ago". Caused by dividing by 0.
Used a ternary expression to check if the denominator is 0 if it is just display the seconds elapsed.

![Screenshot_4](https://user-images.githubusercontent.com/51374812/94827345-f3789880-0425-11eb-8245-8b58f0f70efd.png)

Fixes #46 
