### PR TITLE
[fix] Made year in footer copyright dynamic

### DIFF
--- a/about.html
+++ b/about.html
@@ -190,7 +190,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/activity.html
+++ b/activity.html
@@ -80,7 +80,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/gsoc/ideas-2017.html
+++ b/gsoc/ideas-2017.html
@@ -330,7 +330,7 @@ which in OpenWISP 1 is implemented with <a href="https://github.com/openwisp/Ope
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/gsoc/ideas-2018.html
+++ b/gsoc/ideas-2018.html
@@ -364,7 +364,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/gsoc/ideas-2019.html
+++ b/gsoc/ideas-2019.html
@@ -883,7 +883,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/gsoc/ideas-2020.html
+++ b/gsoc/ideas-2020.html
@@ -573,7 +573,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/history.html
+++ b/history.html
@@ -243,7 +243,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/index.html
+++ b/index.html
@@ -213,7 +213,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/legacy.html
+++ b/legacy.html
@@ -142,7 +142,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/news/battlemeshv9.html
+++ b/news/battlemeshv9.html
@@ -111,7 +111,7 @@ If you are interested in coming join the <a class="http" href="http://ml.ninux.o
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/news/lede.html
+++ b/news/lede.html
@@ -92,7 +92,7 @@ and its now defaulting to its new release: LEDE 17.01.</p>
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/support.html
+++ b/support.html
@@ -149,7 +149,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/thecode.html
+++ b/thecode.html
@@ -149,7 +149,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>

--- a/whatis.html
+++ b/whatis.html
@@ -322,7 +322,7 @@
             <i class="github icon"></i> Github
           </a>
         </div>
-        <p>&copy; 2008-2020 OpenWISP and individual contributors.</p>
+        <p>&copy; 2008-<script>document.write(new Date().getFullYear())</script> OpenWISP and individual contributors.</p>
       </div>
     </div>
   </div>


### PR DESCRIPTION
### Issue:
Year mentioned in the footer was outdated

![image](https://user-images.githubusercontent.com/53327173/109513211-df1af380-7aca-11eb-9011-23bd7449ad77.png)


### Fix:
Made the year dynamic using JavaScript to always show the current year

![image](https://user-images.githubusercontent.com/53327173/109513362-0671c080-7acb-11eb-9106-638e3d30634b.png)