### PR TITLE
[docs] explicitly mention matrix chat room names and refer to `matrix.to` instead of `gitter.im`

### DIFF
--- a/support.html
+++ b/support.html
@@ -88,11 +88,11 @@
             which allows a more asynchronous communication.
         </p>
         <p class="center chat buttons">
-          <a href="https://gitter.im/openwisp/general"
+          <a href="https://matrix.to/#/#openwisp_general:gitter.im"
              class="ui big inverted button red" target="_blank">
             <i class="comment icon"></i> Join the support chat
           </a>
-          <a href="https://gitter.im/openwisp/development"
+          <a href="https://matrix.to/#/#openwisp_development:gitter.im"
              class="ui big inverted button red" target="_blank">
             <i class="comment icon"></i> Join the dev chat
           </a>

--- a/support.html
+++ b/support.html
@@ -74,10 +74,12 @@
         <h2>Chat</h2>
         <p>
             For quick questions you can reach us
-            in the <a href="https://gitter.im/openwisp/general">OpenWISP General</a> chat.
+            in the OpenWISP General chat:
+            <a href="https://matrix.to/#/#openwisp_general:gitter.im"><pre>#openwisp_general:gitter.im</pre></a> (<a href="https://matrix.org/">Matrix</a>).
         </p>
-            Developers and contributors coordinate with one another using
-            <a href="https://gitter.im/openwisp/development">OpenWISP Development</a> chat.
+            Developers and contributors coordinate with one another using the
+            OpenWISP Development chat:
+            <a href="https://matrix.to/#/#openwisp_development:gitter.im"><pre>#openwisp_development:gitter.im</pre></a> (<a href="https://matrix.org/">Matrix</a>).
         <p>
             Since we're on different timezones, it may happen that nobody
             can answer your question while you're active in the chat.<br>


### PR DESCRIPTION
Previously the text and link suggested, that the chat is hosted at `gitter` (which was confusing / deterrent) for Matrix users. A typical approach for linking to a Matrix chat room consists of a `matrix.to` link combined with the raw name of the room.