### PR TITLE
[activityFeed] Sanitize HTML content in activity feed #54

### DIFF
--- a/js/feed.js
+++ b/js/feed.js
@@ -15,6 +15,18 @@ function createActivityFeed(options) {
     return count + " " + interval.label + (count !== 1 ? "s" : "") + " ago";
   }
 
+  function sanitizeAndConvertToHtml(content) {
+    var sanitizedContent = content.replace(/<\/?[a-zA-Z]+>/g, (match) => {
+      if (match.toLowerCase() === "<br>" || match.toLowerCase() === "</br>") {
+        return match;
+      } else {
+        return match.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+      }
+    });
+    var convertedHtmlContent = converter.makeHtml(sanitizedContent);
+    return convertedHtmlContent;
+  }
+
   var converter = new showdown.Converter();
   converter.setFlavor("github");
   converter.setOption({
@@ -161,19 +173,7 @@ function createActivityFeed(options) {
 
       if (!eventType)
         return; // don't display if event not handled above
-      
-      // content sanitization
-      var convertedHtmlContent;
-      if (content) {
-        var sanitizedContent = content.replace(/<\/?[a-zA-Z]+>/g, (match) => {
-          if (match.toLowerCase() === '<br>' || match.toLowerCase() === '</br>') {
-            return match;
-          } else {
-            return match.replace(/</g, "&lt;").replace(/>/g, "&gt;");
-          }
-        });
-        convertedHtmlContent = converter.makeHtml(sanitizedContent);
-      }
+
       if (!$(".feed-container div").length)
         $(".feed-container").html('');
 
@@ -204,7 +204,7 @@ function createActivityFeed(options) {
                   )
                 )
               ).append(
-                content ? convertedHtmlContent : ""
+                content ? sanitizeAndConvertToHtml(content) : ""
               )
             )
           ))

--- a/js/feed.js
+++ b/js/feed.js
@@ -165,14 +165,15 @@ function createActivityFeed(options) {
       // content sanitization
       var convertedHtmlContent;
       if (content) {
-        var sanitizedContent = content
-            .replace(/<br>(?!.*<br>)/g, "#####TEMPBR#####")
-            .replace(/</g, "&lt;")
-            .replace(/>/g, "&gt;")
-            .replace(/#####TEMPBR#####/g, "<br>");
+        var sanitizedContent = content.replace(/<\/?[a-zA-Z]+>/g, (match) => {
+          if (match.toLowerCase() === '<br>' || match.toLowerCase() === '</br>') {
+            return match;
+          } else {
+            return match.replace(/</g, "&lt;").replace(/>/g, "&gt;");
+          }
+        });
         convertedHtmlContent = converter.makeHtml(sanitizedContent);
       }
-      
       if (!$(".feed-container div").length)
         $(".feed-container").html('');
 

--- a/js/feed.js
+++ b/js/feed.js
@@ -161,7 +161,18 @@ function createActivityFeed(options) {
 
       if (!eventType)
         return; // don't display if event not handled above
-
+      
+      // content sanitization
+      var convertedHtmlContent;
+      if (content) {
+        var sanitizedContent = content
+            .replace(/<br>(?!.*<br>)/g, "#####TEMPBR#####")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/#####TEMPBR#####/g, "<br>");
+        convertedHtmlContent = converter.makeHtml(sanitizedContent);
+      }
+      
       if (!$(".feed-container div").length)
         $(".feed-container").html('');
 
@@ -192,7 +203,7 @@ function createActivityFeed(options) {
                   )
                 )
               ).append(
-                content ? converter.makeHtml(content) : ""
+                content ? convertedHtmlContent : ""
               )
             )
           ))


### PR DESCRIPTION
Any content that includes HTML or JS from GitHub is now properly sanitized to prevent third parties from triggering any potentially harmful code when viewing the activity feed. Example: The text "<input>" is rendered as "&lt;input&gt;" and not as an actual HTML input.

Fixes #54