### PR TITLE
[changes] Added temporary links for docs in WHOIS blog

### DIFF
--- a/content/blog/gsoc-25-whois-and-ip-geolocation.rst
+++ b/content/blog/gsoc-25-whois-and-ip-geolocation.rst
@@ -38,12 +38,14 @@ identify anomalies, and streamline troubleshooting by providing context
 about IP addresses directly within the OpenWISP platform.
 
 For further details on these features and their functionality within
-OpenWISP, see the documentation pages listed here:
+OpenWISP, see the documentation pages listed here (**the links below
+temporarily reference GitHub RST files and will be updated to the official
+documentation once merged in master**):
 
 - `WHOIS Lookup
-  <https://openwisp.io/docs/stable/controller/user/whois.html>`_
+  <https://github.com/openwisp/openwisp-controller/blob/issues/1034-fuzzy-location-creation/docs/user/whois.rst>`_
 - `Estimated Location
-  <https://openwisp.io/docs/stable/controller/user/estimated-location.html>`_
+  <https://github.com/openwisp/openwisp-controller/blob/issues/1034-fuzzy-location-creation/docs/user/estimated-location.rst>`_
 
 Building WHOIS and IP Geolocation Functionality
 -----------------------------------------------


### PR DESCRIPTION
The links for official documentation of **WHOIS** and **Estimate location feature** have been replaced temporarily with their respective GitHub RST files. Once the complete feature set (`gsoc25-whois` of openwisp-controller) is merged in master, these links will be updated. 