### PR TITLE
[docs] GSoC26 Automatic Extraction of OpenWrt Firmware Image Metadata blog section

### DIFF
--- a/content/blog/gsoc26-midterm-report.rst
+++ b/content/blog/gsoc26-midterm-report.rst
@@ -2,7 +2,7 @@ OpenWISP 26 Midterm Report
 ==========================
 
 :date: 2026-07-07
-:authors: Federico Capoano,
+:authors: Federico Capoano, Mohammed Atif
 :tags: gsoc, new-features
 :category: gsoc
 :lang: en
@@ -36,7 +36,45 @@ Automatic Extraction of OpenWrt Firmware Image Metadata
 
 Video.
 
-Summary of progress.
+In OpenWISP, matching a firmware image to the devices it can upgrade
+relied on a hardcoded mapping (``hardware.py``) between device models and
+image types. Every new board had to be added to this file by hand, which
+meant adding support for new devices was slow and required a code change
+every time. Automatic metadata extraction removes this static map by
+reading the information directly from the firmware image at upload time.
+
+**Extraction foundation and OpenWrt pipeline** (`PR #421
+<https://github.com/openwisp/openwisp-firmware-upgrader/pull/421>`_): A
+``BaseMetadataExtractor`` abstract base class defines a two-path
+extraction lifecycle so support for other embedded operating systems can
+be added later. The ``OpenWrtMetadataExtractor`` reads the ``fwtool``
+metadata trailer appended to sysupgrade images as a fast path, and falls
+back to scanning the image's device tree blob (DTB) for images that have
+no trailer (e.g. sunxi, ipq40xx initramfs). Extraction is guarded against
+decompression bombs through chunked reading with ratio and size limits,
+and files that are clearly not firmware images (such as JPEG, PNG or PDF)
+are rejected on upload.
+
+**Metadata fields, state machine and async task** (`PR #437
+<https://github.com/openwisp/openwisp-firmware-upgrader/pull/437>`_): The
+``FirmwareImage`` model gains the extracted fields (board, target,
+compatible, firmware version, source) and an extraction status that moves
+an image from ``Unconfirmed`` to ``In Progress`` and finally to
+``Success`` or ``Failed`` as a Celery task processes it after upload. Once
+an image is confirmed, its metadata becomes read-only and a
+``unique_together`` constraint prevents duplicate uploads. When extraction
+cannot fully populate the metadata, a notification links the administrator
+to a manual input page where the missing fields can be filled in by hand.
+Device pairing is migrated off the hardcoded image type map and now uses
+the extracted board field instead.
+
+Currently, device pairing matches an image's board field against the
+device model, which only works when the device matches the image's primary
+board. In the coming weeks, pairing will move to the ``compatible`` field,
+which lists every board an image supports, so images that cover multiple
+boards pair correctly. A data migration will also run extraction
+automatically for images that predate the feature, so administrators do
+not have to trigger it manually.
 
 Add more timeseries database clients to OpenWISP Monitoring
 -----------------------------------------------------------


### PR DESCRIPTION
## Description
- Added a section for the Automatic Extraction of OpenWrt Firmware Image Metadata GSoC midterm report blog.
- With the current link of PRs
- Run openwisp-qa-format

## Todo
- Add video demo 